### PR TITLE
Update 05-validation.md

### DIFF
--- a/packages/forms/docs/05-validation.md
+++ b/packages/forms/docs/05-validation.md
@@ -472,7 +472,7 @@ TextInput::make('slug')->rules([
     function () {
         return function (string $attribute, $value, Closure $fail) {
             if ($value === 'foo') {
-                $fail("The {$attribute} is invalid.");
+                $fail("The :attribute is invalid.");
             }
         };
     },


### PR DESCRIPTION
The substitution field `:attribute` used in a custom validation rule message will honour the `validationAttribute()` if set. In the original example `{$attribute}` will substitute the name of the field exactly as supplied in the `->make('name')` method, and so will usually be wrong (e.g. "first_name" instead of "First Name").

- [x] Changes have been thoroughly tested to not break existing functionality.
- [x] New functionality has been documented or existing documentation has been updated to reflect changes.
- [x] Visual changes are explained in the PR description using a screenshot/recording of before and after.
